### PR TITLE
use gcc13 for linux to force proper toolchain

### DIFF
--- a/pkgs/dogecoin-core/default.nix
+++ b/pkgs/dogecoin-core/default.nix
@@ -23,7 +23,7 @@ let
     nativeBuildInputs = [ pkgs.bzip2 pkgs.perl pkgs.which pkgs.boost-build ];
     buildInputs = [ pkgs.zlib ]
       # Only add GCC explicitly on Linux — on Darwin use clang from stdenv
-      ++ lib.optionals stdenv.hostPlatform.isLinux [ pkgs.gcc ];
+      ++ lib.optionals stdenv.hostPlatform.isLinux [ pkgs.gcc13 ];
 
     configurePhase = ''
       ./bootstrap.sh \


### PR DESCRIPTION
This built on x86_64 with no errors. Might need a few more build tests to make sure it's working properly across the board